### PR TITLE
Add SQLite initialization to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Run the server (default port 8000):
 sd server --port 8000
 ```
 
+The server uses an SQLite database located in the current working
+directory. The database file is created automatically on startup.
+
 Set the target server for API requests:
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,15 @@ setup(
     version='0.1.0',
     author='Jovan Lukovic',
     packages=find_packages(),
+    install_requires=[
+        'fastapi',
+        'uvicorn',
+        'SQLAlchemy',
+    ],
     entry_points={
-        "console_scripts": [
-            "standdown=standdown.__main__:main",
-            "sd=standdown.__main__:main",
+        'console_scripts': [
+            'standdown=standdown.__main__:main',
+            'sd=standdown.__main__:main',
         ]
     }
 )

--- a/standdown/database.py
+++ b/standdown/database.py
@@ -1,0 +1,17 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "sqlite:///standdown.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def init_db():
+    """Create database tables."""
+    Base.metadata.create_all(bind=engine)

--- a/standdown/server.py
+++ b/standdown/server.py
@@ -2,7 +2,15 @@
 
 from fastapi import FastAPI
 
+from .database import init_db
+
 app = FastAPI()
+
+
+@app.on_event("startup")
+def startup_event():
+    """Initialize the SQLite database when the server starts."""
+    init_db()
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
## Summary
- initialize SQLite database when server starts
- add minimal database utilities
- update README with note about DB
- list dependencies in setup.py

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873b9994c9883339e40030d84be8a25