### PR TITLE
Add login command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Run the server (default port 8000):
 sd server --port 8000
 ```
 
+The server uses an SQLite database located in the current working
+directory. The database file is created automatically on startup.
+
 Set the target server for API requests:
 
 ```bash
@@ -17,3 +20,29 @@ sd conn 127.0.0.1:8000
 ```
 
 If no port is given, `sd conn` uses 8000 by default.
+
+Create a new team on the server:
+
+```bash
+sd create <teamname> <adminpwd>
+```
+
+The admin password is stored hashed in the server database. Attempting
+to create a team that already exists will result in an error message.
+
+Add users to a team (the last argument is the password for all users):
+
+```bash
+sd signup <teamname> <adminpwd> <user1> [<user2> ...] <password>
+```
+
+User passwords are stored hashed in the server database.
+
+Login as a user to receive an authentication token:
+
+```bash
+sd login <teamname> <username> <password>
+```
+
+The CLI stores the returned token and team name in the configuration file for
+future requests.

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,15 @@ setup(
     version='0.1.0',
     author='Jovan Lukovic',
     packages=find_packages(),
+    install_requires=[
+        'fastapi',
+        'uvicorn',
+        'SQLAlchemy',
+    ],
     entry_points={
-        "console_scripts": [
-            "standdown=standdown.__main__:main",
-            "sd=standdown.__main__:main",
+        'console_scripts': [
+            'standdown=standdown.__main__:main',
+            'sd=standdown.__main__:main',
         ]
     }
 )

--- a/standdown/__main__.py
+++ b/standdown/__main__.py
@@ -1,7 +1,13 @@
 # standdown/__main__.py
 
 import argparse
-from standdown.cli import start_server, connect
+from standdown.cli import (
+    start_server,
+    connect,
+    create_team_cli,
+    signup_cli,
+    login_cli,
+)
 from standdown.config import DEFAULT_PORT
 
 def main():
@@ -18,12 +24,40 @@ def main():
     conn_parser = subparsers.add_parser('conn', help='Set the server address')
     conn_parser.add_argument('address', help='IP/domain optionally with :port')
 
+    # Subcommand: sd create <team> <admin_password>
+    create_parser = subparsers.add_parser('create', help='Create a team')
+    create_parser.add_argument('teamname', help='Team name')
+    create_parser.add_argument('adminpwd', help='Admin password')
+
+    # Subcommand: sd signup <team> <adminpwd> <usernames...> <password>
+    signup_parser = subparsers.add_parser('signup', help='Add users to a team')
+    signup_parser.add_argument('teamname', help='Team name')
+    signup_parser.add_argument('adminpwd', help='Admin password')
+    signup_parser.add_argument('users', nargs='+', help='List of usernames followed by password (last arg)')
+
+    # Subcommand: sd login <team> <username> <password>
+    login_parser = subparsers.add_parser('login', help='Login as a user')
+    login_parser.add_argument('teamname', help='Team name')
+    login_parser.add_argument('username', help='Username')
+    login_parser.add_argument('password', help='Password')
+
     args = parser.parse_args()
 
     if args.command == 'server':
         start_server(args.port)
     elif args.command == 'conn':
         connect(args.address)
+    elif args.command == 'create':
+        create_team_cli(args.teamname, args.adminpwd)
+    elif args.command == 'signup':
+        if len(args.users) < 2:
+            print("[ERROR] Provide at least one username and a password")
+            return
+        usernames = args.users[:-1]
+        password = args.users[-1]
+        signup_cli(args.teamname, args.adminpwd, usernames, password)
+    elif args.command == 'login':
+        login_cli(args.teamname, args.username, args.password)
     else:
         parser.print_help()
 

--- a/standdown/cli.py
+++ b/standdown/cli.py
@@ -1,8 +1,16 @@
 # standdown/cli.py
 
+import json
+from urllib import request
+
 import uvicorn
 from standdown import server
-from .config import save_server, DEFAULT_PORT
+from .config import (
+    save_server,
+    load_server,
+    save_login,
+    DEFAULT_PORT,
+)
 
 
 def connect(address: str):
@@ -23,3 +31,93 @@ def connect(address: str):
 def start_server(port: int = DEFAULT_PORT):
     print(f"[SERVER] Starting standdown FastAPI server on port {port}")
     uvicorn.run(server.app, host="0.0.0.0", port=port)
+
+
+def create_team_cli(name: str, admin_password: str):
+    """Send a request to create a new team on the configured server."""
+    address, port = load_server()
+    if not address:
+        print("[ERROR] No server configured. Use 'sd conn <address>' first.")
+        return
+
+    url = f"http://{address}:{port}/teams"
+    data = json.dumps({"name": name, "admin_password": admin_password}).encode("utf-8")
+    req = request.Request(url, data=data, headers={"Content-Type": "application/json"})
+
+    try:
+        with request.urlopen(req) as resp:
+            if 200 <= resp.status < 300:
+                print("[CLIENT] Team created")
+            else:
+                print(f"[ERROR] Server responded with status {resp.status}")
+    except Exception as exc:
+        try:
+            # attempt to read error body if available
+            body = exc.read().decode()
+            print(f"[ERROR] {body}")
+        except Exception:
+            print(f"[ERROR] {exc}")
+
+
+def signup_cli(teamname: str, admin_password: str, usernames: list[str], password: str):
+    """Send a request to add users to a team."""
+    address, port = load_server()
+    if not address:
+        print("[ERROR] No server configured. Use 'sd conn <address>' first.")
+        return
+
+    url = f"http://{address}:{port}/teams/{teamname}/users"
+    data = json.dumps({
+        "admin_password": admin_password,
+        "usernames": usernames,
+        "password": password,
+    }).encode("utf-8")
+    req = request.Request(url, data=data, headers={"Content-Type": "application/json"})
+
+    try:
+        with request.urlopen(req) as resp:
+            if 200 <= resp.status < 300:
+                print("[CLIENT] Users created")
+            else:
+                print(f"[ERROR] Server responded with status {resp.status}")
+    except Exception as exc:
+        try:
+            body = exc.read().decode()
+            print(f"[ERROR] {body}")
+        except Exception:
+            print(f"[ERROR] {exc}")
+
+
+def login_cli(teamname: str, username: str, password: str):
+    """Login a user and store the returned token."""
+    address, port = load_server()
+    if not address:
+        print("[ERROR] No server configured. Use 'sd conn <address>' first.")
+        return
+
+    url = f"http://{address}:{port}/login"
+    data = json.dumps({
+        "team_name": teamname,
+        "username": username,
+        "password": password,
+    }).encode("utf-8")
+    req = request.Request(url, data=data, headers={"Content-Type": "application/json"})
+
+    try:
+        with request.urlopen(req) as resp:
+            body = resp.read().decode()
+            if 200 <= resp.status < 300:
+                token = json.loads(body).get("token")
+                if token:
+                    save_login(teamname, token)
+                    print("[CLIENT] Logged in")
+                else:
+                    print("[ERROR] Invalid response from server")
+            else:
+                print(f"[ERROR] Server responded with status {resp.status}: {body}")
+    except Exception as exc:
+        try:
+            body = exc.read().decode()
+            print(f"[ERROR] {body}")
+        except Exception:
+            print(f"[ERROR] {exc}")

--- a/standdown/config.py
+++ b/standdown/config.py
@@ -4,12 +4,36 @@ from pathlib import Path
 DEFAULT_PORT = 8000
 CONFIG_PATH = Path.home() / ".standdown_config.json"
 
+
+def _read() -> dict:
+    if CONFIG_PATH.exists():
+        return json.loads(CONFIG_PATH.read_text())
+    return {}
+
+
+def _write(data: dict):
+    CONFIG_PATH.write_text(json.dumps(data))
+
+
 def save_server(address: str, port: int = DEFAULT_PORT):
-    CONFIG_PATH.write_text(json.dumps({"address": address, "port": port}))
+    data = _read()
+    data["address"] = address
+    data["port"] = port
+    _write(data)
 
 
 def load_server():
-    if CONFIG_PATH.exists():
-        data = json.loads(CONFIG_PATH.read_text())
-        return data.get("address"), data.get("port", DEFAULT_PORT)
-    return None, DEFAULT_PORT
+    data = _read()
+    return data.get("address"), data.get("port", DEFAULT_PORT)
+
+
+def save_login(team: str, token: str):
+    data = _read()
+    data["team"] = team
+    data["token"] = token
+    _write(data)
+
+
+def load_login():
+    data = _read()
+    return data.get("team"), data.get("token")

--- a/standdown/database.py
+++ b/standdown/database.py
@@ -1,0 +1,116 @@
+from sqlalchemy import create_engine, Column, Integer, String, ForeignKey
+from sqlalchemy.orm import sessionmaker, declarative_base, Session
+import hashlib
+import secrets
+
+DATABASE_URL = "sqlite:///standdown.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+class Team(Base):
+    """Database model for a team."""
+
+    __tablename__ = "teams"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True, nullable=False)
+    admin_hash = Column(String, nullable=False)
+
+
+class User(Base):
+    """Database model for a user belonging to a team."""
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    team_id = Column(Integer, ForeignKey("teams.id"), nullable=False)
+
+
+class Token(Base):
+    """Authentication token for a user."""
+
+    __tablename__ = "tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    token = Column(String, unique=True, index=True, nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+
+
+def hash_password(password: str) -> str:
+    """Return a SHA256 hash of the provided password."""
+    return hashlib.sha256(password.encode("utf-8")).hexdigest()
+
+
+def get_team_by_name(db: Session, name: str):
+    """Retrieve a team by its name if it exists."""
+    return db.query(Team).filter(Team.name == name).first()
+
+
+def create_team(db: Session, name: str, admin_password: str) -> Team:
+    """Create a new team with the hashed admin password."""
+    team = Team(name=name, admin_hash=hash_password(admin_password))
+    db.add(team)
+    db.commit()
+    db.refresh(team)
+    return team
+
+
+def get_user_by_username(db: Session, username: str):
+    """Retrieve a user by username if it exists."""
+    return db.query(User).filter(User.username == username).first()
+
+
+def create_user(db: Session, username: str, password: str, team_id: int) -> User:
+    """Create a user belonging to the given team."""
+    user = User(username=username,
+                password_hash=hash_password(password),
+                team_id=team_id)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def create_token(db: Session, user_id: int) -> str:
+    """Create and store an authentication token for the user."""
+    token_str = secrets.token_hex(16)
+    token = Token(token=token_str, user_id=user_id)
+    db.add(token)
+    db.commit()
+    db.refresh(token)
+    return token.token
+
+
+def get_user_for_login(db: Session, team_id: int, username: str, password: str):
+    """Return the user if the credentials are valid."""
+    user = (
+        db.query(User)
+        .filter(User.username == username, User.team_id == team_id)
+        .first()
+    )
+    if user and user.password_hash == hash_password(password):
+        return user
+    return None
+
+
+def get_db():
+    """Yield a database session for use with FastAPI dependencies."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def init_db():
+    """Create database tables."""
+    Base.metadata.create_all(bind=engine)

--- a/standdown/server.py
+++ b/standdown/server.py
@@ -1,9 +1,91 @@
 # standdown/server.py
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from .database import (
+    init_db,
+    get_db,
+    get_team_by_name,
+    create_team,
+    hash_password,
+    get_user_by_username,
+    create_user,
+    create_token,
+    get_user_for_login,
+)
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+def startup_event():
+    """Initialize the SQLite database when the server starts."""
+    init_db()
 
 @app.get("/")
 def read_root():
     return {"message": "Standdown server running"}
+
+
+class TeamCreate(BaseModel):
+    name: str
+    admin_password: str
+
+
+class UsersCreate(BaseModel):
+    admin_password: str
+    usernames: list[str]
+    password: str
+
+
+class LoginRequest(BaseModel):
+    team_name: str
+    username: str
+    password: str
+
+
+@app.post("/teams")
+def create_team_endpoint(payload: TeamCreate, db: Session = Depends(get_db)):
+    """Create a new team if it doesn't already exist."""
+    existing = get_team_by_name(db, payload.name)
+    if existing:
+        raise HTTPException(status_code=400, detail="Team already exists")
+    create_team(db, payload.name, payload.admin_password)
+    return {"message": "Team created"}
+
+
+@app.post("/teams/{team_name}/users")
+def create_users_endpoint(team_name: str, payload: UsersCreate, db: Session = Depends(get_db)):
+    """Add users to a team after verifying the admin password."""
+    team = get_team_by_name(db, team_name)
+    if not team:
+        raise HTTPException(status_code=404, detail="Team not found")
+
+    if team.admin_hash != hash_password(payload.admin_password):
+        raise HTTPException(status_code=403, detail="Invalid admin password")
+
+    created = []
+    for username in payload.usernames:
+        if get_user_by_username(db, username):
+            continue
+        user = create_user(db, username, payload.password, team.id)
+        created.append(user.username)
+
+    return {"message": "Users created", "users": created}
+
+
+@app.post("/login")
+def login_endpoint(payload: LoginRequest, db: Session = Depends(get_db)):
+    """Validate credentials and return an auth token."""
+    team = get_team_by_name(db, payload.team_name)
+    if not team:
+        raise HTTPException(status_code=404, detail="Team not found")
+
+    user = get_user_for_login(db, team.id, payload.username, payload.password)
+    if not user:
+        raise HTTPException(status_code=403, detail="Invalid credentials")
+
+    token = create_token(db, user.id)
+    return {"token": token}


### PR DESCRIPTION
## Summary
- implement login endpoint on server
- store team name and token in config
- add CLI command `sd login`
- document login in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873b9994c9883339e40030d84be8a25