### PR TITLE
Implement team status display

### DIFF
--- a/standdown/__main__.py
+++ b/standdown/__main__.py
@@ -6,6 +6,7 @@ from standdown.cli import (
     start_server,
     connect,
     create_team_cli,
+    show_team_cli,
     signup_cli,
     login_cli,
     send_message_cli,
@@ -19,7 +20,7 @@ def main():
     # If the first argument is not a known subcommand, treat the entire
     # invocation as a message to post.
     known = {
-        'server', 'conn', 'create', 'signup', 'login', 'msg', 'blockers', 'pin'
+        'server', 'conn', 'create', 'signup', 'login', 'msg', 'blockers', 'pin', 'team'
     }
     import sys
     if len(sys.argv) > 1 and sys.argv[1] not in known:
@@ -68,6 +69,8 @@ def main():
     # Subcommand: sd pin <message>
     pin_parser = subparsers.add_parser('pin', help='Send a pin message')
     pin_parser.add_argument('message', help='Message text')
+    # Subcommand: sd team
+    team_parser = subparsers.add_parser("team", help="Show team standup")
 
     login_parser.add_argument('password', help='Password')
 
@@ -96,6 +99,8 @@ def main():
         send_message_cli(args.message, None)
     elif args.command == 'blockers':
         send_message_cli(args.message, 'blockers')
+    elif args.command == 'team':
+        show_team_cli()
     elif args.command == 'pin':
         send_message_cli(args.message, 'pin')
 

--- a/standdown/database.py
+++ b/standdown/database.py
@@ -183,6 +183,20 @@ def create_message(
     db.commit()
     db.refresh(msg)
     return msg
+def get_active_messages(db: Session, team_id: int, msg_type: str | None):
+    """Return active messages for the given team and type."""
+    query = (
+        db.query(User.username, Message.content, Message.timestamp)
+        .join(Message, User.id == Message.user_id)
+        .filter(Message.team_id == team_id, Message.active == True)
+    )
+    if msg_type is None:
+        query = query.filter(Message.msg_type.is_(None))
+    else:
+        query = query.filter(Message.msg_type == msg_type)
+    return query.order_by(User.username.asc()).all()
+
+
 
 
 

--- a/standdown/server.py
+++ b/standdown/server.py
@@ -14,6 +14,7 @@ from .database import (
     get_user_by_username,
     get_user_in_team,
     create_user,
+    get_active_messages,
     create_token,
     get_user_for_login,
     get_user_by_token,
@@ -128,4 +129,23 @@ def post_message_endpoint(payload: MessagePost, db: Session = Depends(get_db)):
 
     create_message(db, user.id, team.id, payload.message, payload.flag)
     return {"message": "Message posted"}
+
+
+
+@app.get("/teams/{team_name}/messages")
+def get_messages_endpoint(team_name: str, msg_type: str | None = None, db: Session = Depends(get_db)):
+    """Return active messages for a team grouped by type."""
+    team = get_team_by_name(db, team_name)
+    if not team:
+        raise HTTPException(status_code=404, detail="Team not found")
+    messages = get_active_messages(db, team.id, msg_type)
+    result = [
+        {
+            "username": username,
+            "content": content,
+            "timestamp": ts.isoformat(),
+        }
+        for username, content, ts in messages
+    ]
+    return {"messages": result}
 


### PR DESCRIPTION
## Summary
- add `_fetch_messages` and `show_team_cli` to print team standup info
- expose message list endpoint on the server
- support message retrieval with `get_active_messages`
- wire new `team` subcommand into CLI

## Testing
- `python -m py_compile standdown/__main__.py standdown/server.py standdown/database.py standdown/cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6874260092c48333be5ed1608e64ef6c