### PR TITLE
Improve team message retrieval

### DIFF
--- a/standdown/cli.py
+++ b/standdown/cli.py
@@ -226,9 +226,10 @@ def show_team_cli():
 
     base_url = f"http://{address}:{port}/teams/{team}/messages"
 
-    pinned = _fetch_messages(base_url + "?type=pin")
-    messages = _fetch_messages(base_url)
-    blockers = _fetch_messages(base_url + "?type=blockers")
+    all_msgs = _fetch_messages(base_url + "?type=all")
+    pinned = [m for m in all_msgs if m.get("msg_type") == "pin"]
+    blockers = [m for m in all_msgs if m.get("msg_type") == "blockers"]
+    messages = [m for m in all_msgs if m.get("msg_type") is None]
 
     def _print_section(title: str, items: list[dict]):
         if not items:

--- a/standdown/server.py
+++ b/standdown/server.py
@@ -133,19 +133,29 @@ def post_message_endpoint(payload: MessagePost, db: Session = Depends(get_db)):
 
 
 @app.get("/teams/{team_name}/messages")
-def get_messages_endpoint(team_name: str, msg_type: str | None = None, db: Session = Depends(get_db)):
-    """Return active messages for a team grouped by type."""
+def get_messages_endpoint(
+    team_name: str, msg_type: str | None = None, db: Session = Depends(get_db)
+):
+    """Return active messages for a team.
+
+    The optional ``msg_type`` query parameter can be ``None`` for regular
+    messages, a specific flag like ``"pin"`` or ``"blockers"``, or ``"all``" to
+    retrieve every active message regardless of flag.
+    """
+
     team = get_team_by_name(db, team_name)
     if not team:
         raise HTTPException(status_code=404, detail="Team not found")
+
     messages = get_active_messages(db, team.id, msg_type)
     result = [
         {
             "username": username,
             "content": content,
+            "msg_type": mtype,
             "timestamp": ts.isoformat(),
         }
-        for username, content, ts in messages
+        for username, content, mtype, ts in messages
     ]
     return {"messages": result}
 


### PR DESCRIPTION
## Summary
- fetch all team messages at once
- group messages by flag client-side
- expose message flag data from the server

## Testing
- `python -m py_compile standdown/*.py`
- `pytest -q`
- `pip install -e .` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6874865ba3d88333b5e9e9047320f976