### PR TITLE
Fix color output by initializing colorama

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
         'fastapi',
         'uvicorn',
         'SQLAlchemy',
+        'colorama',
     ],
     entry_points={
         'console_scripts': [

--- a/standdown/cli.py
+++ b/standdown/cli.py
@@ -3,6 +3,11 @@
 import json
 from urllib import request
 
+from colorama import init as colorama_init
+
+# Initialize color support on all platforms
+colorama_init(autoreset=True)
+
 import uvicorn
 from standdown import server
 


### PR DESCRIPTION
## Summary
- initialize colorama in the CLI for Windows compatibility
- depend on colorama in setup

## Testing
- `python -m py_compile standdown/*.py`
- `pip install -e .` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6874a62acacc833381dc3844e1a72e1d