### PR TITLE
Secure team message retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,13 @@ sd login <teamname> <username> <password>
 The CLI stores the returned token and team name in the configuration file for
 future requests.
 
+Retrieve the current standup messages for your team:
+
+```bash
+sd team
+```
+
+This command requires that you are logged in. The CLI sends your stored
+username and token with the request so that only authenticated team members can
+view the messages.
+

--- a/standdown/cli.py
+++ b/standdown/cli.py
@@ -1,7 +1,7 @@
 # standdown/cli.py
 
 import json
-from urllib import request
+from urllib import request, parse
 
 from colorama import init as colorama_init
 
@@ -225,13 +225,14 @@ def show_team_cli():
         return
 
     team, token, username = load_login()
-    if not team:
+    if not team or not token or not username:
         print("[ERROR] Not logged in. Use 'sd login <team> <username> <password>' first.")
         return
 
     base_url = f"http://{address}:{port}/teams/{team}/messages"
+    params = parse.urlencode({"username": username, "token": token})
 
-    all_msgs = _fetch_messages(base_url)
+    all_msgs = _fetch_messages(f"{base_url}?{params}")
     pinned = [m for m in all_msgs if m.get("msg_type") == "pin"]
     blockers = [m for m in all_msgs if m.get("msg_type") == "blockers"]
     messages = [m for m in all_msgs if m.get("msg_type") is None]

--- a/standdown/server.py
+++ b/standdown/server.py
@@ -134,7 +134,10 @@ def post_message_endpoint(payload: MessagePost, db: Session = Depends(get_db)):
 
 @app.get("/teams/{team_name}/messages")
 def get_messages_endpoint(
-    team_name: str, db: Session = Depends(get_db)
+    team_name: str,
+    username: str,
+    token: str,
+    db: Session = Depends(get_db),
 ):
     """Return active messages for a team.
 
@@ -146,6 +149,14 @@ def get_messages_endpoint(
     team = get_team_by_name(db, team_name)
     if not team:
         raise HTTPException(status_code=404, detail="Team not found")
+
+    user = get_user_in_team(db, team.id, username)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    token_user = get_user_by_token(db, token)
+    if not token_user or token_user.id != user.id:
+        raise HTTPException(status_code=403, detail="Invalid token")
 
     messages = get_active_messages(db, team.id)
     result = [


### PR DESCRIPTION
## Summary
- require username and token when fetching team messages
- update `sd team` command to send authentication
- document the new authentication requirement

## Testing
- `python -m compileall -q standdown`

------
https://chatgpt.com/codex/tasks/task_e_6874ad56bb9083339caee81b036a3579