### PR TITLE
Add URL scheme support to `sd conn`

### DIFF
--- a/standdown/config.py
+++ b/standdown/config.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 DEFAULT_PORT = 8000
+DEFAULT_SCHEME = "http"
 CONFIG_PATH = Path.home() / ".standdown_config.json"
 
 
@@ -15,16 +16,21 @@ def _write(data: dict):
     CONFIG_PATH.write_text(json.dumps(data))
 
 
-def save_server(address: str, port: int = DEFAULT_PORT):
+def save_server(address: str, port: int = DEFAULT_PORT, scheme: str = DEFAULT_SCHEME):
     data = _read()
     data["address"] = address
     data["port"] = port
+    data["scheme"] = scheme
     _write(data)
 
 
 def load_server():
     data = _read()
-    return data.get("address"), data.get("port", DEFAULT_PORT)
+    return (
+        data.get("address"),
+        data.get("port", DEFAULT_PORT),
+        data.get("scheme", DEFAULT_SCHEME),
+    )
 
 
 def save_login(team: str, token: str, username: str):


### PR DESCRIPTION
## Summary
- extend config to store scheme
- update `connect` to parse urls with scheme and port
- build URLs with configured scheme in CLI helpers

## Testing
- `python -m py_compile standdown/cli.py standdown/config.py`
- `pip install colorama` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6874fb7530188333b522441fb53c965d