### PR TITLE
Store per-user salt for password hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add users to a team (the last argument is the password for all users):
 sd signup <teamname> <adminpwd> <user1> [<user2> ...] <password>
 ```
 
-User passwords are stored hashed in the server database.
+User passwords are stored hashed with a unique salt in the server database.
 
 
 Login as a user to receive an authentication token:


### PR DESCRIPTION
## Summary
- extend the user database model with a `salt` column
- generate a random salt when creating a user and store it
- hash and verify passwords using the stored salt
- update password changes to use the salt
- note salted password storage in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68754d5a94648333abd5960498bf6bfc