### PR TITLE
Add today/yesterday log commands

### DIFF
--- a/standdown/cli.py
+++ b/standdown/cli.py
@@ -344,3 +344,37 @@ def show_team_cli():
         _print_section("In progress", messages)
     if blockers:
         _print_section("Blockers", blockers)
+
+
+def show_logs_cli(day: str, flag: str | None, users: list[str]):
+    """Display logs for a specific day and flag."""
+    address, port, scheme = load_server()
+    if not address:
+        print("[ERROR] No server configured. Use 'sd conn <address>' first.")
+        return
+
+    team, token, username = load_login()
+    if not team or not token or not username:
+        print("[ERROR] Not logged in. Use 'sd login <team> <username> <password>' first.")
+        return
+
+    base_url = f"{scheme}://{address}:{port}/teams/{team}/logs"
+    params = {
+        "username": username,
+        "token": token,
+        "date": day,
+        "flag": flag or "none",
+    }
+    if users:
+        params["users"] = ",".join(users)
+
+    url = f"{base_url}?{parse.urlencode(params)}"
+    logs = _fetch_messages(url)
+    if not logs:
+        return
+
+    for msg in logs:
+        ts = datetime.fromisoformat(msg["timestamp"])
+        color = _color_for_user(msg["username"])
+        reset = "\033[0m"
+        print(f"{color}{msg['username']}{reset}: {msg['content']} ({ts.isoformat()})")


### PR DESCRIPTION
## Summary
- support log queries in database and server
- expose `/teams/<team>/logs` endpoint
- implement `sd today` and `sd yesterday`
- allow `sd pin` and `sd blockers` to show logs for today or yesterday
- add CLI helper to print logs

## Testing
- `python -m pip install -e .` *(fails: cannot access pypi)*
- `python -m py_compile standdown/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687559fb4a38833395da251c2ed41475