### PR TITLE
Allow escaping subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ This command requires that you are logged in. The CLI sends your stored
 username and token with the request so that only authenticated team members can
 view the messages.
 
+### Sending standup messages
+
+To post a message, simply run `sd <message>`. If your text begins with a word
+that matches a subcommand (for example `team`), prefix the message with a dot:
+
+```bash
+sd . team is on track
+```
+
+The prefix prevents the CLI from interpreting the word as a command. You can
+also use `sd msg <message>` explicitly.
+
 Clear your standup messages when they no longer apply:
 
 ```bash

--- a/standdown/__main__.py
+++ b/standdown/__main__.py
@@ -29,10 +29,15 @@ def main():
         'today', 'yesterday', 'manager'
     }
     import sys
-    if len(sys.argv) > 1 and sys.argv[1] not in known:
-        message = ' '.join(sys.argv[1:])
-        send_message_cli(message, None)
-        return
+    if len(sys.argv) > 1:
+        if sys.argv[1] == '.':
+            message = ' '.join(sys.argv[2:])
+            send_message_cli(message, None)
+            return
+        if sys.argv[1] not in known:
+            message = ' '.join(sys.argv[1:])
+            send_message_cli(message, None)
+            return
 
     parser = argparse.ArgumentParser(prog='sd', description='standdown CLI')
 


### PR DESCRIPTION
## Summary
- allow sending literal messages by prefixing with a dot
- document the new syntax in README

## Testing
- `python -m standdown --help` *(fails: ModuleNotFoundError: No module named 'colorama')*
- `pip install -e .` *(fails: could not find a version that satisfies the requirement setuptools>=40.8.0)*


------
https://chatgpt.com/codex/tasks/task_e_6875f6364b4c8333b114c6383db7be00