### PR TITLE
Implement task assignment with tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,19 @@ sd blockers done
 
 Each command deactivates the corresponding message type for the logged in user.
 
+### Managing tasks
+
+Managers can create tasks for the team:
+
+```bash
+sd add <task>
+```
+
+The server responds with the hexadecimal tag for the new task, which is also displayed by the CLI.
+
+Managers can assign tasks to team members using the tag:
+
+```bash
+sd assign <tag> <username>
+```
+

--- a/standdown/__main__.py
+++ b/standdown/__main__.py
@@ -15,6 +15,7 @@ from standdown.cli import (
     deactivate_messages_cli,
     reset_password_cli,
     add_task_cli,
+    assign_task_cli,
 )
 
 from standdown.config import DEFAULT_PORT
@@ -27,7 +28,7 @@ def main():
     known = {
         'server', 'conn', 'create', 'signup', 'login', 'msg',
         'blockers', 'pin', 'team', 'resetpwd', 'done',
-        'today', 'yesterday', 'manager', 'add'
+        'today', 'yesterday', 'manager', 'add', 'assign'
     }
     import sys
     if len(sys.argv) > 1:
@@ -104,6 +105,10 @@ def main():
     # Subcommand: sd add <task>
     add_parser = subparsers.add_parser('add', help='Add a task')
     add_parser.add_argument('taskname', help='Task name')
+    # Subcommand: sd assign <tag> <username>
+    assign_parser = subparsers.add_parser('assign', help='Assign a task to a user')
+    assign_parser.add_argument('tag', help='Task tag')
+    assign_parser.add_argument('username', help='User to assign to')
     # Subcommand: sd team
     team_parser = subparsers.add_parser("team", help="Show team standup")
 
@@ -167,6 +172,8 @@ def main():
                 send_message_cli(' '.join(args.params), 'pin')
     elif args.command == 'add':
         add_task_cli(args.taskname)
+    elif args.command == 'assign':
+        assign_task_cli(args.tag, args.username)
     elif args.command == 'done':
         deactivate_messages_cli(None)
     elif args.command == 'team':

--- a/standdown/cli.py
+++ b/standdown/cli.py
@@ -315,7 +315,50 @@ def add_task_cli(taskname: str):
         with request.urlopen(req) as resp:
             body = resp.read().decode()
             if 200 <= resp.status < 300:
-                print("[CLIENT] Task added")
+                data = json.loads(body)
+                tag = data.get("tag")
+                if tag:
+                    print(f"[CLIENT] Task added [{tag}]")
+                else:
+                    print("[CLIENT] Task added")
+            else:
+                print(f"[ERROR] Server responded with status {resp.status}: {body}")
+    except Exception as exc:
+        try:
+            body = exc.read().decode()
+            print(f"[ERROR] {body}")
+        except Exception:
+            print(f"[ERROR] {exc}")
+
+
+def assign_task_cli(tag: str, assignee: str):
+    """Assign a task to a team member."""
+    address, port, scheme = load_server()
+    if not address:
+        print("[ERROR] No server configured. Use 'sd conn <address>' first.")
+        return
+
+    team, token, username = load_login()
+    if not team or not token or not username:
+        print("[ERROR] Not logged in. Use 'sd login <team> <username> <password>' first.")
+        return
+
+    url = f"{scheme}://{address}:{port}/tasks/assign"
+    data = json.dumps({
+        "team_name": team,
+        "username": username,
+        "token": token,
+        "tag": tag,
+        "assignee": assignee,
+    }).encode("utf-8")
+
+    req = request.Request(url, data=data, headers={"Content-Type": "application/json"})
+
+    try:
+        with request.urlopen(req) as resp:
+            body = resp.read().decode()
+            if 200 <= resp.status < 300:
+                print("[CLIENT] Task assigned")
             else:
                 print(f"[ERROR] Server responded with status {resp.status}: {body}")
     except Exception as exc:


### PR DESCRIPTION
## Summary
- add `tag`, `assigned_to`, and `active` fields to tasks
- auto-generate hex task tags and allow task assignment
- extend server API for task creation and assignment
- update CLI with `assign` command and display task tag
- document task management commands

## Testing
- `python -m py_compile standdown/*.py`
- ❌ `pip install colorama fastapi uvicorn SQLAlchemy` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_687603d8d670833386b306e616216677