### PR TITLE
Enable multiple user assignment for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ sd add <task>
 
 The server responds with the hexadecimal tag for the new task, which is also displayed by the CLI.
 
-Managers can assign tasks to team members using the tag:
+Managers can assign tasks to multiple team members using the tag:
 
 ```bash
-sd assign <tag> <username>
+sd assign <tag> <user1> [<user2> ...]
 ```
 

--- a/standdown/__main__.py
+++ b/standdown/__main__.py
@@ -106,9 +106,9 @@ def main():
     add_parser = subparsers.add_parser('add', help='Add a task')
     add_parser.add_argument('taskname', help='Task name')
     # Subcommand: sd assign <tag> <username>
-    assign_parser = subparsers.add_parser('assign', help='Assign a task to a user')
+    assign_parser = subparsers.add_parser('assign', help='Assign a task to users')
     assign_parser.add_argument('tag', help='Task tag')
-    assign_parser.add_argument('username', help='User to assign to')
+    assign_parser.add_argument('usernames', nargs='+', help='Users to assign to')
     # Subcommand: sd team
     team_parser = subparsers.add_parser("team", help="Show team standup")
 
@@ -173,7 +173,7 @@ def main():
     elif args.command == 'add':
         add_task_cli(args.taskname)
     elif args.command == 'assign':
-        assign_task_cli(args.tag, args.username)
+        assign_task_cli(args.tag, args.usernames)
     elif args.command == 'done':
         deactivate_messages_cli(None)
     elif args.command == 'team':

--- a/standdown/cli.py
+++ b/standdown/cli.py
@@ -331,8 +331,8 @@ def add_task_cli(taskname: str):
             print(f"[ERROR] {exc}")
 
 
-def assign_task_cli(tag: str, assignee: str):
-    """Assign a task to a team member."""
+def assign_task_cli(tag: str, assignees: list[str]):
+    """Assign a task to one or more team members."""
     address, port, scheme = load_server()
     if not address:
         print("[ERROR] No server configured. Use 'sd conn <address>' first.")
@@ -349,7 +349,7 @@ def assign_task_cli(tag: str, assignee: str):
         "username": username,
         "token": token,
         "tag": tag,
-        "assignee": assignee,
+        "assignees": assignees,
     }).encode("utf-8")
 
     req = request.Request(url, data=data, headers={"Content-Type": "application/json"})


### PR DESCRIPTION
## Summary
- allow assigning tasks to multiple users
- update server endpoint and CLI to accept many assignees
- store task/user mappings in new association table
- update documentation for new usage

## Testing
- `python -m py_compile standdown/*.py`
- `pip install -e .` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6876079a02288333912ce0272a2a1760