### PR TITLE
Implement task start/end features

### DIFF
--- a/standdown/__main__.py
+++ b/standdown/__main__.py
@@ -18,6 +18,8 @@ from standdown.cli import (
     assign_task_cli,
     list_tasks_cli,
     list_all_tasks_cli,
+    start_task_cli,
+    end_task_cli,
 )
 
 from standdown.config import DEFAULT_PORT
@@ -30,7 +32,8 @@ def main():
     known = {
         'server', 'conn', 'create', 'signup', 'login', 'msg',
         'blockers', 'pin', 'team', 'resetpwd', 'done',
-        'today', 'yesterday', 'manager', 'add', 'assign', 'tasks', 'list'
+        'today', 'yesterday', 'manager', 'add', 'assign', 'tasks', 'list',
+        'start', 'end'
     }
     import sys
     if len(sys.argv) > 1:
@@ -115,6 +118,12 @@ def main():
     tasks_parser = subparsers.add_parser('tasks', help='List tasks assigned to you')
     # Subcommand: sd list
     list_parser = subparsers.add_parser('list', help='List all tasks for the team')
+    # Subcommand: sd start <tag>
+    start_parser = subparsers.add_parser('start', help='Start a task')
+    start_parser.add_argument('tag', help='Task tag')
+    # Subcommand: sd end <tag>
+    end_parser = subparsers.add_parser('end', help='Finish a task')
+    end_parser.add_argument('tag', help='Task tag')
     # Subcommand: sd team
     team_parser = subparsers.add_parser("team", help="Show team standup")
 
@@ -180,6 +189,10 @@ def main():
         add_task_cli(args.taskname)
     elif args.command == 'assign':
         assign_task_cli(args.tag, args.usernames)
+    elif args.command == 'start':
+        start_task_cli(args.tag)
+    elif args.command == 'end':
+        end_task_cli(args.tag)
     elif args.command == 'tasks':
         list_tasks_cli()
     elif args.command == 'list':

--- a/standdown/cli.py
+++ b/standdown/cli.py
@@ -452,6 +452,78 @@ def list_all_tasks_cli():
             print(f"[ERROR] {exc}")
 
 
+def start_task_cli(tag: str):
+    """Start a task by posting its name as a message."""
+    address, port, scheme = load_server()
+    if not address:
+        print("[ERROR] No server configured. Use 'sd conn <address>' first.")
+        return
+
+    team, token, username = load_login()
+    if not team or not token or not username:
+        print("[ERROR] Not logged in. Use 'sd login <team> <username> <password>' first.")
+        return
+
+    url = f"{scheme}://{address}:{port}/tasks/start"
+    data = json.dumps({
+        "team_name": team,
+        "username": username,
+        "token": token,
+        "tag": tag,
+    }).encode("utf-8")
+    req = request.Request(url, data=data, headers={"Content-Type": "application/json"})
+
+    try:
+        with request.urlopen(req) as resp:
+            body = resp.read().decode()
+            if 200 <= resp.status < 300:
+                print("[CLIENT] Task started")
+            else:
+                print(f"[ERROR] Server responded with status {resp.status}: {body}")
+    except Exception as exc:
+        try:
+            body = exc.read().decode()
+            print(f"[ERROR] {body}")
+        except Exception:
+            print(f"[ERROR] {exc}")
+
+
+def end_task_cli(tag: str):
+    """End a task by unassigning it from the current user."""
+    address, port, scheme = load_server()
+    if not address:
+        print("[ERROR] No server configured. Use 'sd conn <address>' first.")
+        return
+
+    team, token, username = load_login()
+    if not team or not token or not username:
+        print("[ERROR] Not logged in. Use 'sd login <team> <username> <password>' first.")
+        return
+
+    url = f"{scheme}://{address}:{port}/tasks/end"
+    data = json.dumps({
+        "team_name": team,
+        "username": username,
+        "token": token,
+        "tag": tag,
+    }).encode("utf-8")
+    req = request.Request(url, data=data, headers={"Content-Type": "application/json"})
+
+    try:
+        with request.urlopen(req) as resp:
+            body = resp.read().decode()
+            if 200 <= resp.status < 300:
+                print("[CLIENT] Task ended")
+            else:
+                print(f"[ERROR] Server responded with status {resp.status}: {body}")
+    except Exception as exc:
+        try:
+            body = exc.read().decode()
+            print(f"[ERROR] {body}")
+        except Exception:
+            print(f"[ERROR] {exc}")
+
+
 from datetime import datetime
 
 


### PR DESCRIPTION
## Summary
- import start/end CLI functions in the main entry point
- expose new `start` and `end` commands
- implement CLI helpers to start or finish a task
- add server endpoints for starting/ending tasks
- support unassigning tasks in the database

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68763340d01083338a6de8bf298e1a39