### PR TITLE
Add task removal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,9 @@ Managers can list every task for the team:
 ```bash
 sd list
 ```
+
+Managers can remove a task by tag:
+
+```bash
+sd remove <tag>
+```

--- a/standdown/__main__.py
+++ b/standdown/__main__.py
@@ -20,6 +20,7 @@ from standdown.cli import (
     list_all_tasks_cli,
     start_task_cli,
     end_task_cli,
+    remove_task_cli,
 )
 
 from standdown.config import DEFAULT_PORT
@@ -33,7 +34,7 @@ def main():
         'server', 'conn', 'create', 'signup', 'login', 'msg',
         'blockers', 'pin', 'team', 'resetpwd', 'done',
         'today', 'yesterday', 'manager', 'add', 'assign', 'tasks', 'list',
-        'start', 'end'
+        'start', 'end', 'remove'
     }
     import sys
     if len(sys.argv) > 1:
@@ -124,6 +125,9 @@ def main():
     # Subcommand: sd end <tag>
     end_parser = subparsers.add_parser('end', help='Finish a task')
     end_parser.add_argument('tag', help='Task tag')
+    # Subcommand: sd remove <tag>
+    remove_parser = subparsers.add_parser('remove', help='Remove a task')
+    remove_parser.add_argument('tag', help='Task tag')
     # Subcommand: sd team
     team_parser = subparsers.add_parser("team", help="Show team standup")
 
@@ -193,6 +197,8 @@ def main():
         start_task_cli(args.tag)
     elif args.command == 'end':
         end_task_cli(args.tag)
+    elif args.command == 'remove':
+        remove_task_cli(args.tag)
     elif args.command == 'tasks':
         list_tasks_cli()
     elif args.command == 'list':

--- a/standdown/cli.py
+++ b/standdown/cli.py
@@ -524,6 +524,42 @@ def end_task_cli(tag: str):
             print(f"[ERROR] {exc}")
 
 
+def remove_task_cli(tag: str):
+    """Deactivate a task as a manager user."""
+    address, port, scheme = load_server()
+    if not address:
+        print("[ERROR] No server configured. Use 'sd conn <address>' first.")
+        return
+
+    team, token, username = load_login()
+    if not team or not token or not username:
+        print("[ERROR] Not logged in. Use 'sd login <team> <username> <password>' first.")
+        return
+
+    url = f"{scheme}://{address}:{port}/tasks/remove"
+    data = json.dumps({
+        "team_name": team,
+        "username": username,
+        "token": token,
+        "tag": tag,
+    }).encode("utf-8")
+    req = request.Request(url, data=data, headers={"Content-Type": "application/json"})
+
+    try:
+        with request.urlopen(req) as resp:
+            body = resp.read().decode()
+            if 200 <= resp.status < 300:
+                print("[CLIENT] Task removed")
+            else:
+                print(f"[ERROR] Server responded with status {resp.status}: {body}")
+    except Exception as exc:
+        try:
+            body = exc.read().decode()
+            print(f"[ERROR] {body}")
+        except Exception:
+            print(f"[ERROR] {exc}")
+
+
 from datetime import datetime
 
 

--- a/standdown/database.py
+++ b/standdown/database.py
@@ -287,6 +287,13 @@ def unassign_task(db: Session, task: Task, user_id: int):
             db.commit()
 
 
+def deactivate_task(db: Session, task: Task):
+    """Mark the task inactive and remove all assignees."""
+    task.active = False
+    db.query(TaskAssignee).filter(TaskAssignee.task_id == task.id).delete()
+    db.commit()
+
+
 def get_tasks_for_user(db: Session, team_id: int, user_id: int) -> list[Task]:
     """Return active tasks assigned to the given user in the team."""
     return (


### PR DESCRIPTION
## Summary
- implement `remove_task_cli` and hook into CLI entrypoints
- support `/tasks/remove` endpoint server-side
- add `deactivate_task` helper in database layer
- document task removal in README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68763df33af88333884e5cf3e201ba86